### PR TITLE
Handle annotations and locations better

### DIFF
--- a/src/vsn_transform.erl
+++ b/src/vsn_transform.erl
@@ -24,8 +24,8 @@ apply_vsn(Forms, Vsn) ->
                   (_) -> false
                end, Forms),
     % Lie about the line number, so we don't offset everything else.
-    Line = 1,
-    VsnAttr = {attribute, Line, vsn, Vsn},
+    Anno = erl_anno:new(1),
+    VsnAttr = {attribute, Anno, vsn, Vsn},
     apply_vsn(HasVsn, VsnAttr, Forms).
 
 apply_vsn(true, _VsnAttr, Forms) ->


### PR DESCRIPTION
This PR is one of several affecting repositories on Github. It
aims at fixing bad use of annotations (see erl_anno(3)). The
following remarks are common to all PR:s.

Typically the second element of abstract code tuples is assumed
to be an integer, which is no longer always true. For instance,
the parse transform implementing QLC tables (see qlc(3)) returns
code where some annotations are marked as `generated'. Such an
annotation is a list, not an integer (it used to be a negative
integer).

As of Erlang/OTP 24.0, the location can be a tuple {Line, Column},
which is another reason to handle annotations properly.